### PR TITLE
Return raw response for `Base#create` and `Base#update`

### DIFF
--- a/lib/myob/api/models/base.rb
+++ b/lib/myob/api/models/base.rb
@@ -52,13 +52,11 @@ module Myob
         def create(object)
           object = typecast(object)
           response = @client.connection.post(self.url, {:headers => @client.headers, :body => object.to_json})
-          response.status == 201
         end
 
         def update(object)
           object = typecast(object)
           response = @client.connection.put(self.url(object), {:headers => @client.headers, :body => object.to_json})
-          response.status == 200
         end
 
         def typecast(object)


### PR DESCRIPTION
Sometimes it's useful to get raw response after create or update methods. For example, when we need to parse some headers(i am parsing UID from just created resource).

@davidlumley if you think it will break backward compatibility we can introduce `#last_response` method, that will return last response data, and create and update methods leave as it was
