### PR TITLE
Allow the OAuth client to receive a configuration block

### DIFF
--- a/lib/myob/api/client.rb
+++ b/lib/myob/api/client.rb
@@ -8,7 +8,7 @@ module Myob
 
       attr_reader :current_company_file, :client
 
-      def initialize(options)
+      def initialize(options, &block)
         Myob::Api::Model::Base.subclasses.each {|c| model(c.name.split("::").last)}
 
         @redirect_uri         = options[:redirect_uri]
@@ -20,7 +20,7 @@ module Myob
           :site          => 'https://secure.myob.com',
           :authorize_url => '/oauth2/account/authorize',
           :token_url     => '/oauth2/v1/authorize',
-        })
+        }, &block)
 
         if options[:company_file]
           @current_company_file = select_company_file(options[:company_file])


### PR DESCRIPTION
OAuth client can receive a block to config its internal http client (based on Faraday). 
https://github.com/intridea/oauth2/blob/0ab3c213f7baa43f232eb18fa46301e1a9460f7d/lib/oauth2/client.rb#L27
Hence, by allowing a block to our constructor, it's enable to change some helpful configurations such as log requests to STDOUT.