### PR TITLE
Rename InvoiceItem to ItemInvoice

### DIFF
--- a/lib/myob-api.rb
+++ b/lib/myob-api.rb
@@ -17,7 +17,7 @@ require 'myob/api/models/employee_standard_pay'
 require 'myob/api/models/employee_payroll_advice'
 
 require 'myob/api/models/invoice'
-require 'myob/api/models/invoice_item'
+require 'myob/api/models/item_invoice'
 
 require 'myob/api/models/payroll_category'
 require 'myob/api/models/wage'

--- a/lib/myob/api/client.rb
+++ b/lib/myob/api/client.rb
@@ -9,7 +9,9 @@ module Myob
       attr_reader :current_company_file, :client
 
       def initialize(options)
-        Myob::Api::Model::Base.subclasses.each {|c| model(c.name.split("::").last)}
+        Myob::Api::Model::Base.descendants.each do |klass|
+          model klass.name.split("::").last
+        end
 
         @redirect_uri         = options[:redirect_uri]
         @consumer             = options[:consumer]

--- a/lib/myob/api/models/item_invoice.rb
+++ b/lib/myob/api/models/item_invoice.rb
@@ -1,10 +1,13 @@
 module Myob
   module Api
     module Model
-      class InvoiceItem < Base
+      class ItemInvoice < Base
         def model_route
           'Sale/Invoice/Item'
         end
+      end
+
+      class InvoiceItem < ItemInvoice
       end
     end
   end


### PR DESCRIPTION
I find it's more clear this way (rather than a line item within an invoice). I've kept the original naming as well for backwards compatibility, but I'd recommend adding a deprecation warning around that and removing it in a later release.