### PR TITLE
Use a refinement

### DIFF
--- a/lib/myob/api/helpers.rb
+++ b/lib/myob/api/helpers.rb
@@ -1,16 +1,21 @@
-class String
-  def underscore
-    self.gsub(/::/, '/').
-    gsub(/([A-Z]+)([A-Z][a-z])/,'\1_\2').
-    gsub(/([a-z\d])([A-Z])/,'\1_\2').
-    tr("-", "_").
-    downcase
-  end
-end
-
 module Myob
   module Api
+
+    module RefinedString
+      refine String do
+        def underscore
+          self.gsub(/::/, '/').
+          gsub(/([A-Z]+)([A-Z][a-z])/,'\1_\2').
+          gsub(/([a-z\d])([A-Z])/,'\1_\2').
+          tr("-", "_").
+          downcase
+        end
+      end
+    end
+
     module Helpers
+      using RefinedString
+
       def model(model_name)
         method_name = model_name.to_s.underscore
         variable_name = "@#{method_name}_model".to_sym
@@ -23,5 +28,6 @@ module Myob
         instance_variable_get(variable_name)
       end
     end
+
   end
 end


### PR DESCRIPTION
Avoid monkey patching since it spills the new implementation all over
the Rails applications that include this gem, overriding the Rails
default  String::underscore.

See http://dev.af83.com/2012/11/05/ruby-2-0-module-refine.html