### PR TITLE
ADD: superannuation payroll category endpoint

### DIFF
--- a/lib/myob-api.rb
+++ b/lib/myob-api.rb
@@ -26,6 +26,7 @@ require 'myob/api/models/payroll_category'
 require 'myob/api/models/wage'
 require 'myob/api/models/entitlement'
 require 'myob/api/models/tax_table'
+require 'myob/api/models/superannuation_category'
 
 require 'myob/api/models/timesheet'
 

--- a/lib/myob/api/models/superannuation_category.rb
+++ b/lib/myob/api/models/superannuation_category.rb
@@ -1,0 +1,11 @@
+module Myob
+  module Api
+    module Model
+      class SuperannuationCategory < Base
+        def model_route
+          'Payroll/PayrollCategory/Superannuation'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the Payroll Category > Superannuation endpoint.

https://developer.myob.com/api/accountright/essentials-new-v2/payroll/payroll-category/superannuation/