### PR TITLE
Add support to banking statement

### DIFF
--- a/lib/myob-api.rb
+++ b/lib/myob-api.rb
@@ -34,4 +34,6 @@ require 'myob/api/models/general_ledger'
 
 require 'myob/api/models/employee_payroll_advice'
 
+require 'myob/api/models/statement'
+
 require 'myob/api/client'

--- a/lib/myob/api/models/statement.rb
+++ b/lib/myob/api/models/statement.rb
@@ -1,0 +1,11 @@
+module Myob
+  module Api
+    module Model
+      class Statement < Base
+        def model_route
+          'Banking/Statement'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
I followed current naming convention (that's why I omit `Banking` in class name)

Reference to myob documentation
https://developer.myob.com/api/accountright/v2/banking/statement/